### PR TITLE
Fix PLATFORM_MIN_VERSION for ARM-based iOS Simulator builds

### DIFF
--- a/Scripts/build/build_leptonica.sh
+++ b/Scripts/build/build_leptonica.sh
@@ -58,7 +58,7 @@ zsh $parentdir/config-make-install_leptonica.sh $name 'ios_arm64' || exit 1
 export ARCH='arm64'
 export TARGET='arm64-apple-ios14.3-simulator'
 export PLATFORM='iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk'
-export PLATFORM_MIN_VERSION='-miphoneos-version-min=14.3'
+export PLATFORM_MIN_VERSION='-mios-simulator-version-min=14.3'
 
 zsh $parentdir/config-make-install_leptonica.sh $name 'ios_arm64_sim' || exit 1
 

--- a/Scripts/build/build_tesseract.sh
+++ b/Scripts/build/build_tesseract.sh
@@ -60,7 +60,7 @@ zsh $parentdir/config-make-install_tesseract.sh $name 'ios_arm64' || exit 1
 export ARCH='arm64'
 export TARGET='arm64-apple-ios14.3-simulator'
 export PLATFORM='iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk'
-export PLATFORM_MIN_VERSION='-miphoneos-version-min=14.3'
+export PLATFORM_MIN_VERSION='-mios-simulator-version-min=14.3'
 
 zsh $parentdir/config-make-install_tesseract.sh $name 'ios_arm64_sim' || exit 1
 


### PR DESCRIPTION
iOS ARM 64 simulator builds used `PLATFORM_MIN_VERSION=-miphoneos-version-min=14.3`, but I think it should be `PLATFORM_MIN_VERSION='-mios-simulator-version-min=14.3'` in line with other platforms.